### PR TITLE
Accept acss_debit as a payment method

### DIFF
--- a/lib/stripe_mock/request_handlers/payment_methods.rb
+++ b/lib/stripe_mock/request_handlers/payment_methods.rb
@@ -115,7 +115,7 @@ module StripeMock
       end
 
       def invalid_type?(type)
-        !%w(card ideal sepa_debit).include?(type)
+        !%w(card ideal sepa_debit acss_debit).include?(type)
       end
     end
   end


### PR DESCRIPTION
To support the ACSS pre-auth debit flow